### PR TITLE
use json.parse only when returning data is string

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ module.exports = function (opts, cb) {
       return;
     }
 
-    var response = JSON.parse(data);
+    var response = (typeof data === "object")?data:JSON.parse(data);
     output.process(opts, response, function(processErr) {
       cb(processErr || err, response);
     });


### PR DESCRIPTION
Hi, I found that when I run the test, it's throw an error "SyntaxError: Unexpected token o".

``` javascript
console.log('data'):
{ kind: 'pagespeedonline#result',
  id: 'https://www.google.co.th/?gws_rd=cr,ssl&ei=SKU7VP3hEMrc8AWu-YHQCw',
  responseCode: 200,
  title: 'Google',
 ...
 ...
  version: { major: 1, minor: 15 } }

SyntaxError: Unexpected token o
    at Object.parse (native)
    at /home/sakp/testpsi/node_modules/psi/index.js:27:25
```
