### PR TITLE
Remove not needed dependencies (plus lodash)

### DIFF
--- a/lib/formats/cli.js
+++ b/lib/formats/cli.js
@@ -1,5 +1,5 @@
 'use strict';
-const _ = require('lodash');
+
 const chalk = require('chalk');
 const utils = require('../utils');
 
@@ -13,14 +13,14 @@ const renderOverview = item => {
 };
 
 const getDataOutput = (data, msg = 'No info provided') => data.length > 0 ?
-  _.map(data, renderSection).join('\n') :
+  data.map(renderSection).join('\n') :
   renderInfo(msg);
 
 module.exports = (overview, statistics, ruleSetResults, opportunities) => {
   return [
     utils.divider,
     setTitle('Summary'),
-    _.map(overview, renderOverview).join('\n') + '\n',
+    overview.map(renderOverview).join('\n') + '\n',
     setTitle('Field Data'),
     getDataOutput(
       statistics,
@@ -28,7 +28,7 @@ module.exports = (overview, statistics, ruleSetResults, opportunities) => {
     ),
     '',
     setTitle('Lab Data'),
-    _.map(ruleSetResults, renderSection).join('\n'),
+    ruleSetResults.map(renderSection).join('\n'),
     '',
     setTitle('Opportunities'),
     getDataOutput(

--- a/lib/formats/json.js
+++ b/lib/formats/json.js
@@ -1,19 +1,16 @@
 'use strict';
-const _ = require('lodash');
+
+const zip = section => section.reduce((acc, current) => {
+  const {label, value} = current;
+  acc[label] = value;
+  return acc;
+}, {});
 
 module.exports = (overview, statistics, ruleSetResults, opportunities) => {
-  const mapSection = section => section.label;
-  const zip = (section, labelMapping) => _.zipObject(_.map(section, labelMapping), _.map(section, 'value'));
-
-  overview = zip(overview, 'label');
-  statistics = zip(statistics, mapSection);
-  ruleSetResults = zip(ruleSetResults, mapSection);
-  opportunities = zip(opportunities, mapSection);
-
   return JSON.stringify({
-    overview,
-    statistics,
-    ruleResults: ruleSetResults,
-    opportunities
+    overview: zip(overview),
+    statistics: zip(statistics),
+    ruleResults: zip(ruleSetResults),
+    opportunities: zip(opportunities)
   }, null, 2);
 };

--- a/lib/output.js
+++ b/lib/output.js
@@ -6,24 +6,20 @@ const prettyMs = require('pretty-ms');
 const THRESHOLD = 70;
 
 function overview(url, strategy, scores) {
-  const ret = [];
-
-  ret.push({
-    label: 'URL',
-    value: url
-  });
-
-  ret.push({
-    label: 'Strategy',
-    value: strategy
-  });
-
-  ret.push({
-    label: 'Performance',
-    value: convertToPercentum(scores.categories.performance.score)
-  });
-
-  return ret;
+  return [
+    {
+      label: 'URL',
+      value: url
+    },
+    {
+      label: 'Strategy',
+      value: strategy
+    },
+    {
+      label: 'Performance',
+      value: convertToPercentum(scores.categories.performance.score)
+    }
+  ];
 }
 
 const fieldData = stats => {
@@ -41,45 +37,39 @@ const fieldData = stats => {
   return sortOn(ret, 'label');
 };
 
-const getRules = (rules, group) => {
-  return rules.filter(rule => {
-    return rule.group === group;
-  });
-};
+const getRules = (rules, group) => rules.filter(rule => rule.group === group);
 
 const labData = lighthouseResult => {
-  const ret = [];
+  const {audits, categories} = lighthouseResult;
+  const rules = getRules(categories.performance.auditRefs, 'metrics');
 
-  const rules = getRules(lighthouseResult.categories.performance.auditRefs, 'metrics');
-
-  rules.forEach(rule => {
-    const {audits} = lighthouseResult;
-    ret.push({
-      label: audits[rule.id].title,
-      value: audits[rule.id].displayValue.replace(/\s/g, '')
-    });
+  const ret = rules.map(rule => {
+    const {title, displayValue} = audits[rule.id];
+    return {
+      label: title,
+      value: displayValue.replace(/\s/g, '')
+    };
   });
 
   return sortOn(ret, 'label');
 };
 
 const opportunities = lighthouseResult => {
-  const ret = [];
-
-  const rules = getRules(lighthouseResult.categories.performance.auditRefs, 'load-opportunities');
+  const {audits, categories} = lighthouseResult;
+  const rules = getRules(categories.performance.auditRefs, 'load-opportunities');
 
   const opportunityRules = rules.filter(rule => {
-    const {details} = lighthouseResult.audits[rule.id];
+    const {details} = audits[rule.id];
     return details.type === 'opportunity' && details.overallSavingsMs > 0;
   });
 
-  for (const rule of opportunityRules) {
-    const {audits} = lighthouseResult;
-    ret.push({
-      label: audits[rule.id].title,
-      value: prettyMs(audits[rule.id].details.overallSavingsMs)
-    });
-  }
+  const ret = opportunityRules.map(rule => {
+    const {title, details} = audits[rule.id];
+    return {
+      label: title,
+      value: prettyMs(details.overallSavingsMs)
+    };
+  });
 
   return sortOn(ret, 'label');
 };

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "devDependencies": {
     "chai": "^4.2.0",
     "mocha": "^6.0.2",
+    "strip-ansi": "^5.1.0",
     "xo": "^0.25.3"
   },
   "xo": {

--- a/package.json
+++ b/package.json
@@ -33,21 +33,19 @@
   ],
   "dependencies": {
     "chalk": "^2.4.2",
-    "download": "^7.0.0",
     "googleapis": "^38.0.0",
     "humanize-url": "^1.0.1",
     "meow": "^5.0.0",
     "pify": "^4.0.0",
     "prepend-http": "^2.0.0",
-    "pretty-bytes": "^5.1.0",
     "pretty-ms": "^4.0.0",
     "sort-on": "^3.0.0",
-    "strip-ansi": "^5.1.0",
     "update-notifier": "^2.5.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",
     "mocha": "^6.0.2",
+    "strip-ansi": "^5.1.0",
     "xo": "^0.24.0"
   },
   "xo": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "download": "^7.0.0",
     "googleapis": "^38.0.0",
     "humanize-url": "^1.0.1",
-    "lodash": "^4.17.11",
     "meow": "^5.0.0",
     "pify": "^4.0.0",
     "prepend-http": "^2.0.0",


### PR DESCRIPTION
This PR fixes https://github.com/GoogleChromeLabs/psi/issues/108

- [x] Remove lodash dependency by using `map` and `reduce`.
- [x] Simplify `output` file by avoiding unnecessary `push` method usage.
- [x] Avoid `for of` and prefer `map`
- [x] Remove not used dependencies and move `strip-ansi` to devDependency (only used for testing).

ℹ️ Manually tested on node 6 to make sure compatibility is kept.