### PR TITLE
Fix/issue 118 metrics of undefined

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -1,58 +1,58 @@
-'use strict';
-const sortOn = require('sort-on');
-const humanizeUrl = require('humanize-url');
-const prettyMs = require('pretty-ms');
-const terminalLink = require('terminal-link');
-const {getThreshold, getReporter} = require('./../lib/options-handler');
-const {getLink} = require('./../lib/string-utils');
+"use strict";
+const sortOn = require("sort-on");
+const humanizeUrl = require("humanize-url");
+const prettyMs = require("pretty-ms");
+const terminalLink = require("terminal-link");
+const { getThreshold, getReporter } = require("./../lib/options-handler");
+const { getLink } = require("./../lib/string-utils");
 
 function overview(url, strategy, scores) {
   return [
     {
-      label: 'URL',
-      value: url
+      label: "URL",
+      value: url,
     },
     {
-      label: 'Strategy',
-      value: strategy
+      label: "Strategy",
+      value: strategy,
     },
     {
-      label: 'Performance',
-      value: convertToPercentum(scores.categories.performance.score)
-    }
+      label: "Performance",
+      value: convertToPercentum(scores.categories.performance.score),
+    },
   ];
 }
 
-const fieldData = stats => {
+const fieldData = (stats) => {
   const ret = [];
 
   for (const title in stats) {
     if (Object.prototype.hasOwnProperty.call(stats, title)) {
       ret.push({
         label: title,
-        value: prettyMs(stats[title].percentile)
+        value: prettyMs(stats[title].percentile),
       });
     }
   }
 
-  return sortOn(ret, 'label');
+  return sortOn(ret, "label");
 };
 
-const getRules = (rules, group) => rules.filter(rule => rule.group === group);
+const getRules = (rules, group) => rules.filter((rule) => rule.group === group);
 
-const labData = lighthouseResult => {
-  const {audits, categories} = lighthouseResult;
-  const rules = getRules(categories.performance.auditRefs, 'metrics');
+const labData = (lighthouseResult) => {
+  const { audits, categories } = lighthouseResult;
+  const rules = getRules(categories.performance.auditRefs, "metrics");
 
-  const ret = rules.map(rule => {
-    const {title, displayValue} = audits[rule.id];
+  const ret = rules.map((rule) => {
+    const { title, displayValue } = audits[rule.id];
     return {
       label: title,
-      value: displayValue.replace(/\s/g, '')
+      value: displayValue.replace(/\s/g, ""),
     };
   });
 
-  return sortOn(ret, 'label');
+  return sortOn(ret, "label");
 };
 
 const getTitle = (title, description) => {
@@ -68,45 +68,56 @@ const getTitle = (title, description) => {
 };
 
 const opportunities = (lighthouseResult, links) => {
-  const {audits, categories} = lighthouseResult;
-  const rules = getRules(categories.performance.auditRefs, 'load-opportunities');
+  const { audits, categories } = lighthouseResult;
+  const rules = getRules(
+    categories.performance.auditRefs,
+    "load-opportunities"
+  );
 
-  const opportunityRules = rules.filter(rule => {
-    const {details} = audits[rule.id];
-    return Boolean(details) && details.type === 'opportunity' && details.overallSavingsMs > 0;
+  const opportunityRules = rules.filter((rule) => {
+    const { details } = audits[rule.id];
+    return details
+      ? details.type === "opportunity" && details.overallSavingsMs > 0
+      : false;
   });
 
-  const ret = opportunityRules.map(rule => {
-    const {title, details, description} = audits[rule.id];
+  const ret = opportunityRules.map((rule) => {
+    const { title, details, description } = audits[rule.id];
 
     return {
       label: links ? getTitle(title, description) : title,
-      value: prettyMs(details.overallSavingsMs)
+      value: prettyMs(details.overallSavingsMs),
     };
   });
 
-  return sortOn(ret, 'label');
+  return sortOn(ret, "label");
 };
 
-const convertToPercentum = num => Math.round(num * 100);
+const convertToPercentum = (num) => Math.round(num * 100);
 
 module.exports = (parameters, response) => {
   return Promise.resolve().then(() => {
     const renderer = require(`./formats/${getReporter(parameters.format)}`);
     const threshold = getThreshold(parameters.threshold);
-    const {lighthouseResult, loadingExperience, id} = response;
+    const { lighthouseResult, loadingExperience = {}, id } = response;
 
-    console.log(renderer(
-      overview(humanizeUrl(id), parameters.strategy, lighthouseResult),
-      fieldData(loadingExperience.metrics),
-      labData(lighthouseResult),
-      opportunities(lighthouseResult, parameters.links),
-      threshold
-    ));
+    console.log(
+      renderer(
+        overview(humanizeUrl(id), parameters.strategy, lighthouseResult),
+        fieldData(loadingExperience.metrics),
+        labData(lighthouseResult),
+        opportunities(lighthouseResult, parameters.links),
+        threshold
+      )
+    );
 
-    const score = convertToPercentum(lighthouseResult.categories.performance.score);
+    const score = convertToPercentum(
+      lighthouseResult.categories.performance.score
+    );
     if (score < threshold) {
-      const error = new Error(`Threshold of ${threshold} not met with score of ${score}`);
+      const error = new Error(
+        `Threshold of ${threshold} not met with score of ${score}`
+      );
       error.noStack = true;
       throw error;
     }

--- a/lib/output.js
+++ b/lib/output.js
@@ -73,7 +73,7 @@ const opportunities = (lighthouseResult, links) => {
 
   const opportunityRules = rules.filter(rule => {
     const {details} = audits[rule.id];
-    return details ? details.type === 'opportunity' && details.overallSavingsMs > 0 : false;
+    return Boolean(details) && details.type === 'opportunity' && details.overallSavingsMs > 0;
   });
 
   const ret = opportunityRules.map(rule => {

--- a/lib/output.js
+++ b/lib/output.js
@@ -1,58 +1,58 @@
-"use strict";
-const sortOn = require("sort-on");
-const humanizeUrl = require("humanize-url");
-const prettyMs = require("pretty-ms");
-const terminalLink = require("terminal-link");
-const { getThreshold, getReporter } = require("./../lib/options-handler");
-const { getLink } = require("./../lib/string-utils");
+'use strict';
+const sortOn = require('sort-on');
+const humanizeUrl = require('humanize-url');
+const prettyMs = require('pretty-ms');
+const terminalLink = require('terminal-link');
+const {getThreshold, getReporter} = require('./../lib/options-handler');
+const {getLink} = require('./../lib/string-utils');
 
 function overview(url, strategy, scores) {
   return [
     {
-      label: "URL",
-      value: url,
+      label: 'URL',
+      value: url
     },
     {
-      label: "Strategy",
-      value: strategy,
+      label: 'Strategy',
+      value: strategy
     },
     {
-      label: "Performance",
-      value: convertToPercentum(scores.categories.performance.score),
-    },
+      label: 'Performance',
+      value: convertToPercentum(scores.categories.performance.score)
+    }
   ];
 }
 
-const fieldData = (stats) => {
+const fieldData = stats => {
   const ret = [];
 
   for (const title in stats) {
     if (Object.prototype.hasOwnProperty.call(stats, title)) {
       ret.push({
         label: title,
-        value: prettyMs(stats[title].percentile),
+        value: prettyMs(stats[title].percentile)
       });
     }
   }
 
-  return sortOn(ret, "label");
+  return sortOn(ret, 'label');
 };
 
-const getRules = (rules, group) => rules.filter((rule) => rule.group === group);
+const getRules = (rules, group) => rules.filter(rule => rule.group === group);
 
-const labData = (lighthouseResult) => {
-  const { audits, categories } = lighthouseResult;
-  const rules = getRules(categories.performance.auditRefs, "metrics");
+const labData = lighthouseResult => {
+  const {audits, categories} = lighthouseResult;
+  const rules = getRules(categories.performance.auditRefs, 'metrics');
 
-  const ret = rules.map((rule) => {
-    const { title, displayValue } = audits[rule.id];
+  const ret = rules.map(rule => {
+    const {title, displayValue} = audits[rule.id];
     return {
       label: title,
-      value: displayValue.replace(/\s/g, ""),
+      value: displayValue.replace(/\s/g, '')
     };
   });
 
-  return sortOn(ret, "label");
+  return sortOn(ret, 'label');
 };
 
 const getTitle = (title, description) => {
@@ -68,56 +68,45 @@ const getTitle = (title, description) => {
 };
 
 const opportunities = (lighthouseResult, links) => {
-  const { audits, categories } = lighthouseResult;
-  const rules = getRules(
-    categories.performance.auditRefs,
-    "load-opportunities"
-  );
+  const {audits, categories} = lighthouseResult;
+  const rules = getRules(categories.performance.auditRefs, 'load-opportunities');
 
-  const opportunityRules = rules.filter((rule) => {
-    const { details } = audits[rule.id];
-    return details
-      ? details.type === "opportunity" && details.overallSavingsMs > 0
-      : false;
+  const opportunityRules = rules.filter(rule => {
+    const {details} = audits[rule.id];
+    return details ? details.type === 'opportunity' && details.overallSavingsMs > 0 : false;
   });
 
-  const ret = opportunityRules.map((rule) => {
-    const { title, details, description } = audits[rule.id];
+  const ret = opportunityRules.map(rule => {
+    const {title, details, description} = audits[rule.id];
 
     return {
       label: links ? getTitle(title, description) : title,
-      value: prettyMs(details.overallSavingsMs),
+      value: prettyMs(details.overallSavingsMs)
     };
   });
 
-  return sortOn(ret, "label");
+  return sortOn(ret, 'label');
 };
 
-const convertToPercentum = (num) => Math.round(num * 100);
+const convertToPercentum = num => Math.round(num * 100);
 
 module.exports = (parameters, response) => {
   return Promise.resolve().then(() => {
     const renderer = require(`./formats/${getReporter(parameters.format)}`);
     const threshold = getThreshold(parameters.threshold);
-    const { lighthouseResult, loadingExperience = {}, id } = response;
+    const {lighthouseResult, loadingExperience = {}, id} = response;
 
-    console.log(
-      renderer(
-        overview(humanizeUrl(id), parameters.strategy, lighthouseResult),
-        fieldData(loadingExperience.metrics),
-        labData(lighthouseResult),
-        opportunities(lighthouseResult, parameters.links),
-        threshold
-      )
-    );
+    console.log(renderer(
+      overview(humanizeUrl(id), parameters.strategy, lighthouseResult),
+      fieldData(loadingExperience.metrics),
+      labData(lighthouseResult),
+      opportunities(lighthouseResult, parameters.links),
+      threshold
+    ));
 
-    const score = convertToPercentum(
-      lighthouseResult.categories.performance.score
-    );
+    const score = convertToPercentum(lighthouseResult.categories.performance.score);
     if (score < threshold) {
-      const error = new Error(
-        `Threshold of ${threshold} not met with score of ${score}`
-      );
+      const error = new Error(`Threshold of ${threshold} not met with score of ${score}`);
       error.noStack = true;
       throw error;
     }


### PR DESCRIPTION
* Cannot read property 'metrics' of undefined
* Cannot read property 'type' of undefined

Reports for some of the sites on the **issue #118**

_https://www.nytimes.com/interactive/2020/world/coronavirus-maps.html_

![nytimes-report](https://user-images.githubusercontent.com/1837650/103813709-d5dc5000-5060-11eb-922f-0e99d8a871ea.png)

_https://hn.svelte.dev/_

![svelte-report](https://user-images.githubusercontent.com/1837650/103813755-e2f93f00-5060-11eb-9dc5-b0d201613333.png)

fixes: #118 
