### PR TITLE
Add Field Data Wording for CLS and LCP

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,7 +3,9 @@ const chalk = require('chalk');
 
 const humanizeTitleMap = {
   FIRST_CONTENTFUL_PAINT_MS: 'First Contentful Paint (FCP)',
-  FIRST_INPUT_DELAY_MS: 'First Input Delay (FID)'
+  FIRST_INPUT_DELAY_MS: 'First Input Delay (FID)',
+  CUMULATIVE_LAYOUT_SHIFT_SCORE: 'Cumulative Layout Shift (CLS)',
+  LARGEST_CONTENTFUL_PAINT_MS: 'Largest Contentful Paint (LCP)',
 };
 
 exports.divider = '\n' + chalk.grey('-'.repeat(56)) + '\n';

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,7 +5,7 @@ const humanizeTitleMap = {
   FIRST_CONTENTFUL_PAINT_MS: 'First Contentful Paint (FCP)',
   FIRST_INPUT_DELAY_MS: 'First Input Delay (FID)',
   CUMULATIVE_LAYOUT_SHIFT_SCORE: 'Cumulative Layout Shift (CLS)',
-  LARGEST_CONTENTFUL_PAINT_MS: 'Largest Contentful Paint (LCP)',
+  LARGEST_CONTENTFUL_PAINT_MS: 'Largest Contentful Paint (LCP)'
 };
 
 exports.divider = '\n' + chalk.grey('-'.repeat(56)) + '\n';


### PR DESCRIPTION
Now that CLS and LCP are part of field data, they need to have entries in the `humanizeTitleMap` so that they're worded better.