### PR TITLE
upgrade googleapis package to fix issue #123

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "psi",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "PageSpeed Insights with reporting",
   "license": "Apache-2.0",
   "repository": "GoogleChromeLabs/psi",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   ],
   "dependencies": {
     "chalk": "^3.0.0",
-    "googleapis": "^47.0.0",
+    "googleapis": "^71.0.0",
     "humanize-url": "^2.1.0",
     "meow": "^6.0.1",
     "pify": "^5.0.0",


### PR DESCRIPTION
fix security issues identified in #123 by updating googleapis from `47.0.0` to `71.0.0`

-- note I'm assuming this would need to go to a 4.2.0 branch first